### PR TITLE
Use UUID for AuthSignaturePrivateKey and fix product setting and port.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,18 +19,26 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get install -y ffmpeg
 
+RUN apt-get install -y curl
+
 # Copy the published application
 COPY . /source
+
+RUN UUID=$(cat /proc/sys/kernel/random/uuid) && \
+    FFMPEG_PATH=$(which ffmpeg) && \
+    FFPROBE_PATH=$(which ffprobe) && \
+    echo '{ "BunnyStorageZoneName": "", "BunnyCdnRootUrl": "", "BunnyAccessKey": "", "BunnyBasePath": "", "BunnyTokenKey": "","BunnyUserApiKey": "", "AuthSignaturePrivateKey": "'$UUID'", "FfprobePath": "'$FFPROBE_PATH'", "FfmpegPath": "'$FFMPEG_PATH'"}' > /source/config/settings.json
 
 # Set the working directory
 WORKDIR /source/IeeeVisUploader/IeeeVisUploaderWebApp
 RUN dotnet publish -c release -o /webapp
 
 # Expose the port your application runs on
-EXPOSE 5103
+EXPOSE 5000
 
 # Set environment variables if necessary (e.g., ASPNETCORE_ENVIRONMENT)
-# ENV ASPNETCORE_ENVIRONMENT=Production
+ENV ASPNETCORE_ENVIRONMENT=Production
+ENV ASPNETCORE_URLS=http://+:5000
 
 WORKDIR /webapp
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,13 @@ The web app needs three configuration files in the folder 'config'.
 ]
 ```
 
+# Run with Docker
 
+To build the docker image using the Dockerfile, run the following command:
+`docker build -t ieee-vis-uploader-webapp . `
+
+To create a docker container:
+`docker run -d -p 5000:5000 --name ieee-vis-uploader-webapp-container ieee-vis-uploader-webapp`
 
 
 # License


### PR DESCRIPTION
Use UUID for  AuthSignaturePrivateKey and change to production setting and port 5000. 

Updated README to add instructions for docker. 